### PR TITLE
Update to work with v10

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,16 +1,26 @@
 {
-  "name": "show-secrets",
+  "id": "show-secrets",
   "title": "Show Secrets",
   "description": "Show secret blocks in chat messages.",
-  "author": "kaelad",
-  "version": "0.1",
-  "minimumCoreVersion": "0.8.9",
-  "compatibleCoreVersion": "9",
-  "dependencies": [
+  "authors": [
     {
-      "name": "lib-wrapper"
+      "name": "kaelad",
+      "discord": "kaelad#1693"
     }
   ],
+  "version": "0.1",
+  "compatibility": {
+    "minimum": "10",
+    "verified": "10"
+  },
+  "relationships": {
+    "requires": [
+      {
+        "id": "lib-wrapper",
+        "type": "module"
+      }
+    ]
+  },
   "esmodules": [
     "src/module.js"
   ],

--- a/src/module.js
+++ b/src/module.js
@@ -23,23 +23,70 @@ Hooks.once("init", () => {
 function initCommon() {
   libWrapper.register(
     "show-secrets",
-    "CONFIG.ChatMessage.documentClass.prototype.prepareData",
-    function (wrapped, ...args) {
-      if (!showSecrets()) return wrapped(...args);
-
-      Object.getPrototypeOf(ChatMessage).prototype.prepareData.apply(this);
-      const actor =
-        this.constructor.getSpeakerActor(this.data.speaker) ||
-        this.user?.character;
-      const rollData = actor ? actor.getRollData() : {};
-      const owner = actor ? actor.isOwner : false;
-      this.data.update({
-        content: TextEditor.enrichHTML(this.data.content, {
-          secrets: owner,
-          rollData,
-        }),
-      });
-    },
+    "CONFIG.ChatMessage.documentClass.prototype.getHTML",
+    wrappedGetHTML,
     "MIXED"
   );
+}
+
+async function wrappedGetHTML(wrapped, ...args) {
+  if (!showSecrets()) return wrapped(...args);
+
+  // Determine some metadata
+  const data = this.toObject(false);
+  const actor = this.constructor.getSpeakerActor(this.speaker) || this.user?.character;
+  const rollData = actor ? actor.getRollData() : {};
+  // Show secrets if we're the owner
+  const secrets = actor ? actor.isOwner : false;
+  data.content = await TextEditor.enrichHTML(this.content, {async: true, rollData, secrets});
+  const isWhisper = this.whisper.length;
+
+  // Construct message data
+  const messageData = {
+    message: data,
+    user: game.user,
+    author: this.user,
+    alias: this.alias,
+    cssClass: [
+      this.type === CONST.CHAT_MESSAGE_TYPES.IC ? "ic" : null,
+      this.type === CONST.CHAT_MESSAGE_TYPES.EMOTE ? "emote" : null,
+      isWhisper ? "whisper" : null,
+      this.blind ? "blind": null
+    ].filterJoin(" "),
+    isWhisper: this.whisper.some(id => id !== game.user.id),
+    canDelete: game.user.isGM,  // Only GM users are allowed to have the trash-bin icon in the chat log itself
+    whisperTo: this.whisper.map(u => {
+      let user = game.users.get(u);
+      return user ? user.name : null;
+    }).filterJoin(", ")
+  };
+
+  // Render message data specifically for ROLL type messages
+  if ( this.isRoll ) {
+    await this._renderRollContent(messageData);
+  }
+
+  // Define a border color
+  if ( this.type === CONST.CHAT_MESSAGE_TYPES.OOC ) {
+    messageData.borderColor = this.user.color;
+  }
+
+  // Render the chat message
+  let html = await renderTemplate(CONFIG.ChatMessage.template, messageData);
+  html = $(html);
+
+  // Flag expanded state of dice rolls
+  if ( this._rollExpanded ) html.find(".dice-tooltip").addClass("expanded");
+
+  /**
+   * A hook event that fires for each ChatMessage which is rendered for addition to the ChatLog.
+   * This hook allows for final customization of the message HTML before it is added to the log.
+   * @function renderChatMessage
+   * @memberof hookEvents
+   * @param {ChatMessage} message   The ChatMessage document being rendered
+   * @param {jQuery} html           The pending HTML as a jQuery object
+   * @param {object} data           The input data provided for template rendering
+   */
+  Hooks.call("renderChatMessage", this, html, messageData);
+  return html;
 }


### PR DESCRIPTION
Only works with v10 because it moved the `prepareData` changes I was wrapping into `getHTML`. I could have supported both versions at the same time but just seemed easier to make a clean break from v9.